### PR TITLE
Add playerhead utility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,5 +71,12 @@
             <version>1.17.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.mojang/authlib -->
+        <dependency>
+            <groupId>com.mojang</groupId>
+            <artifactId>authlib</artifactId>
+            <version>1.5.25</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/itzshmulik/survivelist/survivelistdisguises/SurvivelistDisguises.java
+++ b/src/main/java/itzshmulik/survivelist/survivelistdisguises/SurvivelistDisguises.java
@@ -38,6 +38,12 @@ public final class SurvivelistDisguises extends JavaPlugin {
         headsByPlayer.clear();
     }
 
+    /**
+     * Get a player head item by its base64 texture value.
+     *
+     * @param textureValue the texture's Base64 string
+     * @return a new player head item
+     */
     public static ItemStack headByTexture(@NotNull String textureValue) {
         final ItemStack itemStack = instance.headsByTexture.get(textureValue);
         if (itemStack != null) return new ItemStack(itemStack);
@@ -48,6 +54,16 @@ public final class SurvivelistDisguises extends JavaPlugin {
         return new ItemStack(generated);
     }
 
+    /**
+     * Get a custom-named player head item by its base64 texture value.
+     *
+     * @param textureValue the texture's Base64 string
+     * @param itemName a custom item name
+     * @return a new player head item
+     * @implNote If {@code itemName} is null, this implementation simply
+     *           delegates to {@link #headByTexture(String)} where
+     *           {@code textureValue} is passed as the String parameter.
+     */
     public static ItemStack headByTextureWithName(@NotNull String textureValue, String itemName) {
         if (itemName == null) return headByTexture(textureValue);
         final String cacheKey = textureValue + ":" + itemName;
@@ -60,6 +76,12 @@ public final class SurvivelistDisguises extends JavaPlugin {
         return new ItemStack(generated);
     }
 
+    /**
+     * Get a player head item for a Bukkit player.
+     *
+     * @param player the player (may also be online)
+     * @return a new player head item
+     */
     public static ItemStack headByPlayer(@NotNull OfflinePlayer player) {
         final UUID uniqueId = player.getUniqueId();
         final ItemStack itemStack = instance.headsByPlayer.get(uniqueId);

--- a/src/main/java/itzshmulik/survivelist/survivelistdisguises/SurvivelistDisguises.java
+++ b/src/main/java/itzshmulik/survivelist/survivelistdisguises/SurvivelistDisguises.java
@@ -1,13 +1,26 @@
 package itzshmulik.survivelist.survivelistdisguises;
 
+import itzshmulik.survivelist.survivelistdisguises.util.HeadGrabber;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import itzshmulik.survivelist.survivelistdisguises.commands.DisguiseCommand;
 import itzshmulik.survivelist.survivelistdisguises.events.MenuListener;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.UUID;
+
 public final class SurvivelistDisguises extends JavaPlugin {
+
+    private static SurvivelistDisguises instance;
+    private final HashMap<String, ItemStack> headsByTexture = new HashMap<>();
+    private final HashMap<UUID, ItemStack> headsByPlayer = new HashMap<>();
 
     @Override
     public void onEnable() {
         // Plugin startup logic
+        instance = this;
 
         getCommand("disguise").setExecutor(new DisguiseCommand());
 
@@ -16,5 +29,45 @@ public final class SurvivelistDisguises extends JavaPlugin {
         getConfig().options().copyDefaults();
         saveDefaultConfig();
 
+    }
+
+    @Override
+    public void onDisable() {
+        // clear caches
+        headsByTexture.clear();
+        headsByPlayer.clear();
+    }
+
+    public static ItemStack headByTexture(@NotNull String textureValue) {
+        final ItemStack itemStack = instance.headsByTexture.get(textureValue);
+        if (itemStack != null) return new ItemStack(itemStack);
+        final ItemStack generated = new HeadGrabber.CustomTexture(textureValue).generate();
+        synchronized (instance.headsByTexture) {
+            instance.headsByTexture.put(textureValue, generated);
+        }
+        return new ItemStack(generated);
+    }
+
+    public static ItemStack headByTextureWithName(@NotNull String textureValue, String itemName) {
+        if (itemName == null) return headByTexture(textureValue);
+        final String cacheKey = textureValue + ":" + itemName;
+        final ItemStack itemStack = instance.headsByTexture.get(cacheKey);
+        if (itemStack != null) return new ItemStack(itemStack);
+        final ItemStack generated = new HeadGrabber.CustomTexture(textureValue, itemName).generate();
+        synchronized (instance.headsByTexture) {
+            instance.headsByTexture.put(cacheKey, generated);
+        }
+        return new ItemStack(generated);
+    }
+
+    public static ItemStack headByPlayer(@NotNull OfflinePlayer player) {
+        final UUID uniqueId = player.getUniqueId();
+        final ItemStack itemStack = instance.headsByPlayer.get(uniqueId);
+        if (itemStack != null) return new ItemStack(itemStack);
+        final ItemStack generated = new HeadGrabber.Player(player).generate();
+        synchronized (instance.headsByTexture) {
+            instance.headsByPlayer.put(uniqueId, generated);
+        }
+        return new ItemStack(generated);
     }
 }

--- a/src/main/java/itzshmulik/survivelist/survivelistdisguises/util/HeadGrabber.java
+++ b/src/main/java/itzshmulik/survivelist/survivelistdisguises/util/HeadGrabber.java
@@ -1,0 +1,105 @@
+package itzshmulik.survivelist.survivelistdisguises.util;
+
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+/**
+ * Produces player head ItemStacks.
+ */
+public interface HeadGrabber {
+    /**
+     * Generate a new player head item.
+     *
+     * @return a new item
+     */
+    @NotNull ItemStack generate();
+
+    /**
+     * Produce a player head from an OfflinePlayer.
+     * <p>
+     * Works with {@code Player} as well.
+     */
+    class Player implements HeadGrabber {
+        private final OfflinePlayer player;
+
+        /**
+         * Produce heads for the given player.
+         *
+         * @param player a Bukkit player
+         */
+        public Player(@NotNull OfflinePlayer player) {
+            this.player = player;
+        }
+
+        @Override
+        public @NotNull ItemStack generate() {
+            final ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+            final SkullMeta meta = (SkullMeta) head.getItemMeta();
+            meta.setOwningPlayer(player);
+            head.setItemMeta(meta);
+            return head;
+        }
+    }
+
+    /**
+     * Produce custom-texture player heads from a base64 value.
+     */
+    class CustomTexture implements HeadGrabber {
+        static final Method SKULL_META_SET_PROFILE;
+
+        static {
+            try {
+                // MC>=1.14
+                SKULL_META_SET_PROFILE = new ItemStack(Material.PLAYER_HEAD).getItemMeta().getClass().getDeclaredMethod("setProfile", GameProfile.class);
+                SKULL_META_SET_PROFILE.setAccessible(true);
+            } catch (NoSuchMethodException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        final GameProfile gameProfile;
+
+        /**
+         * Produce heads with the given base64 texture value.
+         *
+         * @param textureValue a Base64 texture string
+         */
+        public CustomTexture(@Nullable String textureValue) {
+            this(textureValue, "Player");
+        }
+
+        /**
+         * Produce heads with the given base64 texture value.
+         *
+         * @param textureValue a Base64 texture string
+         * @param headName a custom name for the item
+         */
+        public CustomTexture(@Nullable String textureValue, String headName) {
+            this.gameProfile = new GameProfile(UUID.randomUUID(), headName);
+            gameProfile.getProperties().put("textures", new Property("textures", textureValue));
+        }
+
+        @Override
+        public @NotNull ItemStack generate() throws IllegalStateException {
+            final ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+            final SkullMeta meta = (SkullMeta) head.getItemMeta();
+            try {
+                SKULL_META_SET_PROFILE.invoke(meta, gameProfile);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new IllegalStateException(e);
+            }
+            head.setItemMeta(meta);
+            return head;
+        }
+    }
+}

--- a/src/main/java/itzshmulik/survivelist/survivelistdisguises/util/HeadGrabber.java
+++ b/src/main/java/itzshmulik/survivelist/survivelistdisguises/util/HeadGrabber.java
@@ -30,7 +30,7 @@ public interface HeadGrabber {
      * Works with {@code Player} as well.
      */
     class Player implements HeadGrabber {
-        private final OfflinePlayer player;
+        final OfflinePlayer player;
 
         /**
          * Produce heads for the given player.
@@ -45,7 +45,12 @@ public interface HeadGrabber {
         public @NotNull ItemStack generate() {
             final ItemStack head = new ItemStack(Material.PLAYER_HEAD);
             final SkullMeta meta = (SkullMeta) head.getItemMeta();
-            meta.setOwningPlayer(player);
+            // try to use paper's profile system for Bukkit (online) Player objects
+            if (player instanceof org.bukkit.entity.Player) {
+                meta.setPlayerProfile(((org.bukkit.entity.Player) player).getPlayerProfile());
+            } else {
+                meta.setOwningPlayer(player);
+            }
             head.setItemMeta(meta);
             return head;
         }


### PR DESCRIPTION
Prefer to use the static factories on the main plugin class, as these are provided a caching system.
- `SurvivelistDisguises.headByTexture(String)`
- `SurvivelistDisguises.headByTextureWithName(String, String)`
- `SurvivelistDisguises.headByPlayer(OfflinePlayer)`

Actual implementations reside in `HeadGrabber` and can be used if caching is not needed
- `new HeadGrabber.CustomTexture(String).generate()`
- `new HeadGrabber.CustomTexture(String, String).generate()`
- `new HeadGrabber.Player(OfflinePlayer).generate()`